### PR TITLE
Update SocketFactory to pass TrustManagerListener to CBLWebSocket

### DIFF
--- a/android/lib/src/main/java/com/couchbase/lite/internal/SocketFactory.java
+++ b/android/lib/src/main/java/com/couchbase/lite/internal/SocketFactory.java
@@ -18,19 +18,23 @@ package com.couchbase.lite.internal;
 import android.os.Build;
 import android.support.annotation.NonNull;
 
+import java.security.cert.Certificate;
+import java.util.List;
+
 import com.couchbase.lite.ReplicatorConfiguration;
 import com.couchbase.lite.internal.core.C4Socket;
 import com.couchbase.lite.internal.replicator.AbstractCBLWebSocket;
-import com.couchbase.lite.internal.replicator.CBLTrustManager;
+import com.couchbase.lite.internal.utils.Fn;
 
 
 public class SocketFactory {
-    private final CBLTrustManager.CBLTrustManagerListener trustManagerListener;
+    @NonNull
+    private final Fn.Consumer<List<Certificate>> serverCertsListener;
 
     public SocketFactory(
             @NonNull ReplicatorConfiguration ignore,
-            @NonNull CBLTrustManager.CBLTrustManagerListener trustManagerListener) {
-        this.trustManagerListener = trustManagerListener;
+            @NonNull Fn.Consumer<List<Certificate>> serverCertsListener) {
+        this.serverCertsListener = serverCertsListener;
     }
 
     public C4Socket createSocket(long handle, String scheme, String hostname, int port, String path, byte[] options) {
@@ -39,6 +43,6 @@ public class SocketFactory {
         }
 
         return AbstractCBLWebSocket.createCBLWebSocket(
-                handle, scheme, hostname, port, path, options, trustManagerListener);
+                handle, scheme, hostname, port, path, options, serverCertsListener);
     }
 }

--- a/android/lib/src/main/java/com/couchbase/lite/internal/SocketFactory.java
+++ b/android/lib/src/main/java/com/couchbase/lite/internal/SocketFactory.java
@@ -21,16 +21,24 @@ import android.support.annotation.NonNull;
 import com.couchbase.lite.ReplicatorConfiguration;
 import com.couchbase.lite.internal.core.C4Socket;
 import com.couchbase.lite.internal.replicator.AbstractCBLWebSocket;
+import com.couchbase.lite.internal.replicator.CBLTrustManager;
 
 
 public class SocketFactory {
-    public SocketFactory(@NonNull ReplicatorConfiguration ignore) { }
+    private final CBLTrustManager.CBLTrustManagerListener trustManagerListener;
+
+    public SocketFactory(
+            @NonNull ReplicatorConfiguration ignore,
+            @NonNull CBLTrustManager.CBLTrustManagerListener trustManagerListener) {
+        this.trustManagerListener = trustManagerListener;
+    }
 
     public C4Socket createSocket(long handle, String scheme, String hostname, int port, String path, byte[] options) {
         if (Build.VERSION.SDK_INT < 21) {
             throw new UnsupportedOperationException("Couchbase sockets require Android version >= 21");
         }
 
-        return AbstractCBLWebSocket.createCBLWebSocket(handle, scheme, hostname, port, path, options);
+        return AbstractCBLWebSocket.createCBLWebSocket(
+                handle, scheme, hostname, port, path, options, trustManagerListener);
     }
 }

--- a/java/lib/src/main/java/com/couchbase/lite/internal/SocketFactory.java
+++ b/java/lib/src/main/java/com/couchbase/lite/internal/SocketFactory.java
@@ -20,12 +20,20 @@ import android.support.annotation.NonNull;
 import com.couchbase.lite.ReplicatorConfiguration;
 import com.couchbase.lite.internal.core.C4Socket;
 import com.couchbase.lite.internal.replicator.AbstractCBLWebSocket;
+import com.couchbase.lite.internal.replicator.CBLTrustManager;
 
 
 public class SocketFactory {
-    public SocketFactory(@NonNull ReplicatorConfiguration ignore) { }
+    private final CBLTrustManager.CBLTrustManagerListener trustManagerListener;
+
+    public SocketFactory(
+        @NonNull ReplicatorConfiguration ignore,
+        CBLTrustManager.CBLTrustManagerListener trustManagerListener) {
+        this.trustManagerListener = trustManagerListener;
+    }
 
     public C4Socket createSocket(long handle, String scheme, String hostname, int port, String path, byte[] options) {
-        return AbstractCBLWebSocket.createCBLWebSocket(handle, scheme, hostname, port, path, options);
+        return AbstractCBLWebSocket.createCBLWebSocket(
+            handle, scheme, hostname, port, path, options, trustManagerListener);
     }
 }

--- a/java/lib/src/main/java/com/couchbase/lite/internal/SocketFactory.java
+++ b/java/lib/src/main/java/com/couchbase/lite/internal/SocketFactory.java
@@ -17,23 +17,27 @@ package com.couchbase.lite.internal;
 
 import android.support.annotation.NonNull;
 
+import java.security.cert.Certificate;
+import java.util.List;
+
 import com.couchbase.lite.ReplicatorConfiguration;
 import com.couchbase.lite.internal.core.C4Socket;
 import com.couchbase.lite.internal.replicator.AbstractCBLWebSocket;
-import com.couchbase.lite.internal.replicator.CBLTrustManager;
+import com.couchbase.lite.internal.utils.Fn;
 
 
 public class SocketFactory {
-    private final CBLTrustManager.CBLTrustManagerListener trustManagerListener;
+    @NonNull
+    private final Fn.Consumer<List<Certificate>> serverCertsListener;
 
     public SocketFactory(
         @NonNull ReplicatorConfiguration ignore,
-        CBLTrustManager.CBLTrustManagerListener trustManagerListener) {
-        this.trustManagerListener = trustManagerListener;
+        Fn.Consumer<List<Certificate>> serverCertsListener) {
+        this.serverCertsListener = serverCertsListener;
     }
 
     public C4Socket createSocket(long handle, String scheme, String hostname, int port, String path, byte[] options) {
         return AbstractCBLWebSocket.createCBLWebSocket(
-            handle, scheme, hostname, port, path, options, trustManagerListener);
+            handle, scheme, hostname, port, path, options, serverCertsListener);
     }
 }


### PR DESCRIPTION
* This change is a part of implementing replicator’s server certificates and allow only self-signed cert feature.
* Reference: CBL-1167 and CBL-1168