### PR TITLE
Fix Java packaging

### DIFF
--- a/android/etc/jenkins/publish.sh
+++ b/android/etc/jenkins/publish.sh
@@ -57,11 +57,11 @@ echo "======== Copy artifacts to staging directory"
 POM_FILE='pom.xml'
 cp lib/build/outputs/aar/*.aar "${ARTIFACTS}/"
 cp lib/build/libs/*.jar "${ARTIFACTS}/"
-cp lib/build/publications/mavenJava/pom-default.xml "${ARTIFACTS}/${POM_FILE}"
+cp lib/build/publications/libRelease/pom-default.xml "${ARTIFACTS}/${POM_FILE}"
 
 echo "======== Pull dependencies for zip"
 DEPS_DIR="${WORKSPACE}/dependencies"
-rm -rf "${DEPS_DIR}"
+rm -rf "${DEPS_DIR}" || true
 mkdir -p "${DEPS_DIR}"
 pushd "${DEPS_DIR}"
 cp "${ARTIFACTS}/${POM_FILE}" ./pom.xml
@@ -72,12 +72,13 @@ popd
 
 echo "======== Create zip"
 ZIP_STAGING="${WORKSPACE}/staging"
-rm -rf "${ZIP_STAGING}"
+rm -rf "${ZIP_STAGING}" || true
 mkdir -p "${ZIP_STAGING}"
 pushd "${ZIP_STAGING}"
-cp "${DEPS_DIR}/target/dependency/"*.jar .
-cp "${WORKSPACE}/cbl-java/legal/mobile/couchbase-lite/license/LICENSE_${EDITION}.txt" ./LICENSE.TXT
-cp "${ARTIFACTS}/${PRODUCT}-${VERSION}-${BUILD_NUMBER}-release.aar" "./${PRODUCT}-${VERSION}.aar"
+mkdir license lib
+cp "${WORKSPACE}/cbl-java/legal/mobile/couchbase-lite/license/LICENSE_${EDITION}.txt" license/LICENSE.TXT
+cp "${DEPS_DIR}/target/dependency/"*.jar lib
+cp "${ARTIFACTS}/${PRODUCT}-${VERSION}-${BUILD_NUMBER}-release.aar" "lib/${PRODUCT}-${VERSION}.aar"
 zip -r "${ARTIFACTS}/${PRODUCT}-${VERSION}-android_${EDITION}.zip" *
 popd
 

--- a/java/etc/jenkins/publish_linux.sh
+++ b/java/etc/jenkins/publish_linux.sh
@@ -34,24 +34,23 @@ if [ -z "$WORKSPACE" ]; then
     usage
 fi
 
+DIST_NAME="${PRODUCT}-${VERSION}-${BUILD_NUMBER}"
+
 echo "======== PUBLISH Couchbase Lite Java, Community Edition v`cat ../../version.txt`-${BUILD_NUMBER}" 
 ./gradlew ciPublish -PbuildNumber=${BUILD_NUMBER} -PmavenUrl=${MAVEN_URL} || exit 1
 
-echo "======== Add license to zip"
-LICENSE_DIR="${WORKSPACE}/license"
-rm -rf "${LICENSE_DIR}"
-mkdir -p "${LICENSE_DIR}"
-cp "${WORKSPACE}/cbl-java/legal/mobile/couchbase-lite/license/LICENSE_community.txt" "${LICENSE_DIR}/LICENSE.TXT" || exit 1
-
-pushd lib/build/distributions
-zip -u "${PRODUCT}-${VERSION}-${BUILD_NUMBER}.zip" "${LICENSE_DIR}/LICENSE.TXT"
-rm -rf "${LICENSE_DIR}"
-popd
-
 echo "======== Copy artifacts to staging directory"
-cp "lib/build/distributions/${PRODUCT}-${VERSION}-${BUILD_NUMBER}.zip" "${ARTIFACTS}/"
+cp "lib/build/distributions/${DIST_NAME}.zip" "${ARTIFACTS}/"
 cp lib/build/libs/*.jar "${ARTIFACTS}/"
 cp lib/build/publications/couchbaseLiteJava/pom-default.xml "${ARTIFACTS}/pom.xml"
+
+echo "======== Add license to zip"
+cd "${WORKSPACE}"
+LICENSE_DIR="${DIST_NAME}/license"
+rm -rf "${LICENSE_DIR}" || true
+mkdir -p "${LICENSE_DIR}"
+cp "cbl-java/legal/mobile/couchbase-lite/license/LICENSE_community.txt" "${LICENSE_DIR}/LICENSE.txt" || exit 1
+zip -u "${ARTIFACTS}/${DIST_NAME}.zip" "${LICENSE_DIR}/LICENSE.txt"
 
 find "${ARTIFACTS}"
 echo "======== PUBLICATION COMPLETE"

--- a/java/lib/build.gradle
+++ b/java/lib/build.gradle
@@ -85,6 +85,7 @@ ext {
     CBL_NATIVE_DIR = "${buildDir}/native"
     CBL_JNI_INCLUDE_DIR = "${GENERATED_DIR}/include"
 
+    DEPENDENCIES = ["okio", "okhttp"]
     OKHTTP_VERSION = "3.14.7"
 }
 
@@ -470,11 +471,19 @@ jar { archivesBaseName = "${CBL_ARTIFACT_ID}" }
 
 distributions {
     main {
+        distributionBaseName = "${CBL_ARTIFACT_ID}"
         contents {
-            distributionBaseName = "${CBL_ARTIFACT_ID}"
-            into("support") {
-                from "${CBL_CORE_NATIVE_DIR}/support"
+            into("support") { from "${CBL_CORE_NATIVE_DIR}/support" }
+
+            include {
+                def name = it.name
+                // allow it if it is a directory,
+                // it is nested in a folder (name != path)
+                // is our artifact
+                // is an explicit dependency
+                return it.isDirectory() || (!name.equals(it.getPath())) || name.startsWith(CBL_ARTIFACT_ID) || DEPENDENCIES.contains(name.split("-")[0])
             }
+
             eachFile {
                 // Move the main jar file into lib folder
                 if (it.name.startsWith("${CBL_ARTIFACT_ID}") &&
@@ -521,7 +530,7 @@ publishing {
             artifactId "${CBL_ARTIFACT_ID}${PLATFORM}"
             version BUILD_VERSION
 
-            from components.java
+            artifact jar
             artifact sourcesJar
             artifact javadocJar
 
@@ -552,6 +561,19 @@ publishing {
                     url = CBL_SITE_URL
                     connection = CBL_PROJECT_URL
                     developerConnection = CBL_PROJECT_URL
+                }
+                withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    // Include only configured dependencies
+                    configurations.implementation.allDependencies.each {
+                        if (DEPENDENCIES.contains(it.name)) {
+                            def dep = dependenciesNode.appendNode('dependency')
+                            dep.appendNode('groupId', it.group)
+                            dep.appendNode('artifactId', it.name)
+                            dep.appendNode('version', it.version)
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix the packaging for the Java release.  We had to do this by hand, for 2.8.0.
1) Correct the name of the release mavenJava -> libRelease
2) put the license in the zip file in a top-level directory named "license"
3) include only explicitly named dependencies (currently okhttp and okio)
