### PR TITLE
Stop gradle daemon after a gradle task is done

### DIFF
--- a/java/etc/jenkins/build_windows.ps1
+++ b/java/etc/jenkins/build_windows.ps1
@@ -21,7 +21,11 @@ Write-Host "======== Download Lite Core"
 & $toolsDir/fetch_litecore.ps1 $LiteCoreRepoUrl -Edition "CE"
 
 Write-Host "======== Build Java"
+<<<<<<< HEAD
 $process = Start-Process -FilePath "$PSScriptRoot\..\..\gradlew.bat" -ArgumentList "ciBuild --info -PbuildNumber=$buildNumber" -PassThru -Wait
+=======
+$process = Start-Process -FilePath "$PSScriptRoot\..\..\gradlew.bat" -ArgumentList "--no-daemon ciBuild -PbuildNumber=$buildNumber" -PassThru -Wait
+>>>>>>> 3771cfdf (Stop gradle daemon after a gradle task is done)
 if($process.ExitCode -ne 0){
     Write-Host "Failed with error" $process.ExitCode 
     exit $process.ExitCode

--- a/java/etc/jenkins/build_windows.ps1
+++ b/java/etc/jenkins/build_windows.ps1
@@ -21,11 +21,7 @@ Write-Host "======== Download Lite Core"
 & $toolsDir/fetch_litecore.ps1 $LiteCoreRepoUrl -Edition "CE"
 
 Write-Host "======== Build Java"
-<<<<<<< HEAD
-$process = Start-Process -FilePath "$PSScriptRoot\..\..\gradlew.bat" -ArgumentList "ciBuild --info -PbuildNumber=$buildNumber" -PassThru -Wait
-=======
 $process = Start-Process -FilePath "$PSScriptRoot\..\..\gradlew.bat" -ArgumentList "--no-daemon ciBuild -PbuildNumber=$buildNumber" -PassThru -Wait
->>>>>>> 3771cfdf (Stop gradle daemon after a gradle task is done)
 if($process.ExitCode -ne 0){
     Write-Host "Failed with error" $process.ExitCode 
     exit $process.ExitCode

--- a/java/etc/jenkins/publish_windows.ps1
+++ b/java/etc/jenkins/publish_windows.ps1
@@ -17,7 +17,7 @@ $mavenUrl= "http://proget.build.couchbase.com/maven2/cimaven"
 $status = 0
 
 Write-Host "======== PUBLISH Couchbase Lite Java for Windows, Community Edition"
-$process = Start-Process -FilePath "$PSScriptRoot\..\..\gradlew.bat" -ArgumentList "ciPublish -PbuildNumber=$buildNumber" -PassThru -Wait
+$process = Start-Process -FilePath "$PSScriptRoot\..\..\gradlew.bat" -ArgumentList "--no-daemon ciPublish -PbuildNumber=$buildNumber" -PassThru -Wait
 if($process.ExitCode -ne 0){
     $status = 5
 }

--- a/java/etc/jenkins/test_windows.ps1
+++ b/java/etc/jenkins/test_windows.ps1
@@ -12,7 +12,7 @@ Set-PSDebug -Trace 1
 $status = 0
 
 Write-Host "======== TEST Couchbase Lite Java for Windows, Community Edition"
-$process = Start-Process -FilePath "$PSScriptRoot\..\..\gradlew.bat" -ArgumentList "ciTest --console=plain -PautomatedTests=true -PbuildNumber=$buildNumber  > test.log 2>&1" -PassThru -Wait
+$process = Start-Process -FilePath "$PSScriptRoot\..\..\gradlew.bat" -ArgumentList "--no-daemon ciTest --console=plain -PautomatedTests=true -PbuildNumber=$buildNumber" -PassThru -Wait
 if($process.ExitCode -ne 0){
     $status = 5
 }

--- a/java/etc/jenkins/test_windows.ps1
+++ b/java/etc/jenkins/test_windows.ps1
@@ -12,7 +12,7 @@ Set-PSDebug -Trace 1
 $status = 0
 
 Write-Host "======== TEST Couchbase Lite Java for Windows, Community Edition"
-$process = Start-Process -FilePath "$PSScriptRoot\..\..\gradlew.bat" -ArgumentList "--no-daemon ciTest --console=plain -PautomatedTests=true -PbuildNumber=$buildNumber" -PassThru -Wait
+$process = Start-Process -FilePath "$PSScriptRoot\..\..\gradlew.bat" -ArgumentList "--no-daemon ciTest --console=plain -PautomatedTests=true -PbuildNumber=$buildNumber > test.log 2>&1" -PassThru -Wait
 if($process.ExitCode -ne 0){
     $status = 5
 }


### PR DESCRIPTION
Gradle daemon continues running in the background even after a task is done, and powershell `-wait` only exits the parent process when all subprocesses exit. This causes a hang in the ps script. Stopping Gradle daemon after a gradle task completes will resolve this issue. 