### PR TITLE
Fix android build

### DIFF
--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -426,8 +426,8 @@ task jacocoTestReport(type: JacocoReport) {
 /////// Maven Publishing
 // https://docs.gradle.org/current/userguide/publishing_maven.html
 
-def mavenRepoUser = System.getenv(MAVEN_REPO_USR)
-def mavenRepoPass = System.getenv(MAVEN_REPO_PASS)
+def mavenRepoUser = System.getenv("MAVEN_REPO_USR")
+def mavenRepoPass = System.getenv("MAVEN_REPO_PASS")
 
 // Annoying workaround for Android POM generation
 def pomConfig = {


### PR DESCRIPTION
There are also several changes to the android Jenkins **build** and **publish** scripts. Changes in the build script exclude this recent fix from versions before 3.1, and MAVEN_REPO_USR is added to publish script for 3.1 build.gradle. 

The comparison of original vs current configuration is here: http://mobile.jenkins.couchbase.com/job/couchbase-lite-android-edition-build/jobConfigHistory/showDiffFiles?timestamp1=2022-05-04_10-41-25&timestamp2=2022-05-04_13-23-47