### PR TITLE
Publish Gradle Module Metadata and variant info

### DIFF
--- a/android-ktx/gradle.properties
+++ b/android-ktx/gradle.properties
@@ -27,3 +27,4 @@ android.useAndroidX=true
 android.enableJetifier=false
 android.disableAutomaticComponentCreation=true
 
+kotlin.stdlib.default.dependency=false

--- a/android-ktx/lib/build.gradle
+++ b/android-ktx/lib/build.gradle
@@ -78,9 +78,6 @@ def MAVEN_URL = (project.hasProperty("mavenUrl")) ? mavenUrl : "http://nowhere.v
 //     ./gradlew -Pcoverage=true coverage
 def COVERAGE = project.hasProperty("coverage")
 
-// Set true to use mavenLocal instead of Proget
-def USE_LOCAL_MAVEN = project.hasProperty("useLocalMaven")
-
 
 // ----------------------------------------------------------------
 // Build
@@ -169,7 +166,7 @@ android {
 }
 
 repositories {
-    if (USE_LOCAL_MAVEN) { mavenLocal() }
+    if (BUILD_NUMBER == "SNAPSHOT") { mavenLocal() }
     else {
         maven {
             url "http://proget.build.couchbase.com/maven2/cimaven"
@@ -185,10 +182,10 @@ dependencies {
     // androidx.work:work-runtime-ktx:2.8.0 requires 1.3.0
     compileOnly 'androidx.annotation:annotation:1.3.0'
 
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
+    compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
 
     // Work Manager support
-    implementation "androidx.work:work-runtime-ktx:2.8.1"
+    compileOnly "androidx.work:work-runtime-ktx:2.8.1"
 
     implementation("com.couchbase.lite:${CBL_ANDROID_LIB}:${BUILD_VERSION}") { changing = true }
 
@@ -199,7 +196,10 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.5.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
+    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
+
     // Work Manager Test support
+    androidTestImplementation "androidx.work:work-runtime-ktx:2.8.1"
     androidTestImplementation "androidx.work:work-testing:2.8.1"
 }
 
@@ -317,7 +317,7 @@ project.afterEvaluate {
                 artifactId CBL_ARTIFACT_ID
                 version BUILD_VERSION
 
-                artifact bundleReleaseAar
+                from components.release
                 artifact dokkaJar
                 artifact sourcesJar
 
@@ -326,13 +326,6 @@ project.afterEvaluate {
                     def root = asNode()
                     root.appendNode('description', CBL_DESCRIPTION)
                     root.children().last() + pomConfig
-
-                    def dependenciesNode = root.appendNode('dependencies')
-                    def dep = dependenciesNode.appendNode('dependency')
-                    dep.appendNode('groupId', CBL_GROUP)
-                    dep.appendNode('artifactId', CBL_ANDROID_LIB)
-                    dep.appendNode('version', BUILD_VERSION)
-                    dep.appendNode('type', CBL_ANDROID_TYPE)
                 }
             }
 
@@ -341,7 +334,7 @@ project.afterEvaluate {
                 artifactId CBL_ARTIFACT_ID
                 version BUILD_VERSION
 
-                artifact bundleDebugAar
+                from components.debug
                 artifact dokkaJar
                 artifact sourcesJar
 
@@ -350,13 +343,6 @@ project.afterEvaluate {
                     def root = asNode()
                     root.appendNode('description', CBL_DESCRIPTION)
                     root.children().last() + pomConfig
-
-                    def dependenciesNode = root.appendNode('dependencies')
-                    def dep = dependenciesNode.appendNode('dependency')
-                    dep.appendNode('groupId', CBL_GROUP)
-                    dep.appendNode('artifactId', CBL_ANDROID_LIB)
-                    dep.appendNode('version', BUILD_VERSION)
-                    dep.appendNode('type', CBL_ANDROID_TYPE)
                 }
             }
         }

--- a/android-ktx/lib/build.gradle
+++ b/android-ktx/lib/build.gradle
@@ -326,6 +326,15 @@ project.afterEvaluate {
                     def root = asNode()
                     root.appendNode('description', CBL_DESCRIPTION)
                     root.children().last() + pomConfig
+
+                    def dependencies = root.dependencies.dependency
+
+                    // Include only configured dependencies
+                    dependencies.each {
+                        if (CBL_ANDROID_LIB != it.artifactId.last().value().last()) {
+                            it.parent().remove(it)
+                        }
+                    }
                 }
             }
 
@@ -343,6 +352,15 @@ project.afterEvaluate {
                     def root = asNode()
                     root.appendNode('description', CBL_DESCRIPTION)
                     root.children().last() + pomConfig
+
+                    def dependencies = root.dependencies.dependency
+
+                    // Include only configured dependencies
+                    dependencies.each {
+                        if (CBL_ANDROID_LIB != it.artifactId.last().value().last()) {
+                            it.parent().remove(it)
+                        }
+                    }
                 }
             }
         }

--- a/android-ktx/test/build.gradle
+++ b/android-ktx/test/build.gradle
@@ -56,9 +56,6 @@ ext {
 // e.g., -PtestFilter='com.couchbase.lite.internal.utils.SlowTest,com.couchbase.lite.internal.utils.VerySlowTest'
 def TEST_FILTER = (!project.hasProperty("testFilter")) ? null : testFilter.replaceAll("\\s", "")
 
-// Set true to use mavenLocal instead of Proget
-def USE_LOCAL_MAVEN = project.hasProperty("useLocalMaven")
-
 
 // ----------------------------------------------------------------
 // Build
@@ -124,7 +121,7 @@ android {
 }
 
 repositories {
-    if (USE_LOCAL_MAVEN) { mavenLocal() }
+    if (BUILD_NUMBER == "SNAPSHOT") { mavenLocal() }
     else {
         maven {
             url "http://proget.build.couchbase.com/maven2/cimaven"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -27,3 +27,4 @@ android.useAndroidX=true
 android.enableJetifier=false
 android.disableAutomaticComponentCreation=true
 
+kotlin.stdlib.default.dependency=false

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -510,6 +510,7 @@ project.afterEvaluate {
         canBeResolved = false
         canBeConsumed = true
         attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.LIBRARY))
             attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objects.named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM))
             attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm)
             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
@@ -526,6 +527,7 @@ project.afterEvaluate {
         canBeResolved = false
         canBeConsumed = true
         attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.LIBRARY))
             attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objects.named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM))
             attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm)
             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_RUNTIME))

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -516,6 +516,7 @@ project.afterEvaluate {
         }
     }
 
+    // Add variant artifact as a dependencies, since it's in another module
     dependencies {
         javaApi("com.couchbase.lite:couchbase-lite-java:$version")
     }
@@ -532,6 +533,8 @@ project.afterEvaluate {
     }
 
     // AdhocComponentWithVariants is wrapped by anonymous component class, find it with reflection
+    // can be replaced with (components.release as AdhocComponentWithVariants)
+    // with this fix: https://youtrack.jetbrains.com/issue/KT-58830
     def adhocField = components.release.class.getDeclaredFields()
             .find { it.getType() == AdhocComponentWithVariants }
     adhocField.setAccessible(true)

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -508,7 +508,7 @@ project.afterEvaluate {
                 artifactId CBL_ARTIFACT_ID
                 version BUILD_VERSION
 
-                artifact bundleReleaseAar
+                from components.release
                 artifact sourcesJar
                 artifact javadocJar
 
@@ -517,18 +517,6 @@ project.afterEvaluate {
                     def root = asNode()
                     root.appendNode('description', CBL_DESCRIPTION)
                     root.children().last() + pomConfig
-
-                    def dependenciesNode = root.appendNode('dependencies')
-
-                    // Include only configured dependencies
-                    configurations.implementation.allDependencies.each {
-                        if (DEPENDENCIES.contains(it.name)) {
-                            def dep = dependenciesNode.appendNode('dependency')
-                            dep.appendNode('groupId', it.group)
-                            dep.appendNode('artifactId', it.name)
-                            dep.appendNode('version', it.version)
-                        }
-                    }
                 }
             }
 
@@ -537,7 +525,7 @@ project.afterEvaluate {
                 artifactId CBL_ARTIFACT_ID
                 version BUILD_VERSION
 
-                artifact bundleDebugAar
+                from components.debug
                 artifact sourcesJar
                 artifact javadocJar
 
@@ -546,18 +534,6 @@ project.afterEvaluate {
                     def root = asNode()
                     root.appendNode('description', CBL_DESCRIPTION)
                     root.children().last() + pomConfig
-
-                    def dependenciesNode = root.appendNode('dependencies')
-
-                    // Include only configured dependencies
-                    configurations.implementation.allDependencies.each {
-                        if (DEPENDENCIES.contains(it.name)) {
-                            def dep = dependenciesNode.appendNode('dependency')
-                            dep.appendNode('groupId', it.group)
-                            dep.appendNode('artifactId', it.name)
-                            dep.appendNode('version', it.version)
-                        }
-                    }
                 }
             }
         }

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -540,9 +540,11 @@ project.afterEvaluate {
     adhocComponent.with {
         addVariantsFromConfiguration(javaApiConfig) {
             mapToMavenScope("compile")
+            mapToOptional()
         }
         addVariantsFromConfiguration(javaRuntimeConfig) {
             mapToMavenScope("runtime")
+            mapToOptional()
         }
     }
 
@@ -561,6 +563,15 @@ project.afterEvaluate {
                     def root = asNode()
                     root.appendNode('description', CBL_DESCRIPTION)
                     root.children().last() + pomConfig
+
+                    def dependencies = root.dependencies.dependency
+
+                    // Include only configured dependencies
+                    dependencies.each {
+                        if (!DEPENDENCIES.contains(it.artifactId.last().value().last())) {
+                            it.parent().remove(it)
+                        }
+                    }
                 }
             }
 
@@ -577,6 +588,15 @@ project.afterEvaluate {
                     def root = asNode()
                     root.appendNode('description', CBL_DESCRIPTION)
                     root.children().last() + pomConfig
+
+                    def dependencies = root.dependencies.dependency
+
+                    // Include only configured dependencies
+                    dependencies.each {
+                        if (!DEPENDENCIES.contains(it.artifactId.last().value().last())) {
+                            it.parent().remove(it)
+                        }
+                    }
                 }
             }
         }

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -17,6 +17,10 @@
 // Please try to keep this build file as similar to the other family build files
 // as is possible.
 //
+
+import org.gradle.api.attributes.java.TargetJvmEnvironment
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+
 import java.time.Instant
 import java.util.regex.Pattern
 
@@ -501,6 +505,47 @@ publishing {
 }
 
 project.afterEvaluate {
+    // Include Java variant definition in Gradle Module Metadata
+    def javaApiConfig = configurations.create("javaApi").tap {
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objects.named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM))
+            attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm)
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
+        }
+    }
+
+    dependencies {
+        javaApi("com.couchbase.lite:couchbase-lite-java:$version")
+    }
+
+    def javaRuntimeConfig = configurations.create("javaRuntime").tap {
+        extendsFrom(javaApiConfig)
+        canBeResolved = false
+        canBeConsumed = true
+        attributes {
+            attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objects.named(TargetJvmEnvironment.class, TargetJvmEnvironment.STANDARD_JVM))
+            attribute(KotlinPlatformType.attribute, KotlinPlatformType.jvm)
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_RUNTIME))
+        }
+    }
+
+    // AdhocComponentWithVariants is wrapped by anonymous component class, find it with reflection
+    def adhocField = components.release.class.getDeclaredFields()
+            .find { it.getType() == AdhocComponentWithVariants }
+    adhocField.setAccessible(true)
+    AdhocComponentWithVariants adhocComponent = adhocField.get(components.release)
+
+    adhocComponent.with {
+        addVariantsFromConfiguration(javaApiConfig) {
+            mapToMavenScope("compile")
+        }
+        addVariantsFromConfiguration(javaRuntimeConfig) {
+            mapToMavenScope("runtime")
+        }
+    }
+
     publishing {
         publications {
             libRelease(MavenPublication) {
@@ -512,7 +557,6 @@ project.afterEvaluate {
                 artifact sourcesJar
                 artifact javadocJar
 
-                // include dependencies
                 pom.withXml {
                     def root = asNode()
                     root.appendNode('description', CBL_DESCRIPTION)
@@ -529,7 +573,6 @@ project.afterEvaluate {
                 artifact sourcesJar
                 artifact javadocJar
 
-                // include dependencies
                 pom.withXml {
                     def root = asNode()
                     root.appendNode('description', CBL_DESCRIPTION)

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -19,3 +19,4 @@ org.gradle.jvmargs=-Xmx4608m
 # Required to publish to ProGet (see https://github.com/gradle/gradle/issues/11308)
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
+kotlin.stdlib.default.dependency=false

--- a/java/lib/build.gradle
+++ b/java/lib/build.gradle
@@ -634,9 +634,11 @@ def androidRuntimeConfig = configurations.create("androidRuntime").tap {
 (components.java as AdhocComponentWithVariants).with {
     addVariantsFromConfiguration(androidApiConfig) {
         mapToMavenScope("compile")
+        mapToOptional()
     }
     addVariantsFromConfiguration(androidRuntimeConfig) {
         mapToMavenScope("runtime")
+        mapToOptional()
     }
 }
 
@@ -680,6 +682,17 @@ publishing {
                     url = CBL_SITE_URL
                     connection = CBL_PROJECT_URL
                     developerConnection = CBL_PROJECT_URL
+                }
+
+                withXml {
+                    def dependencies = asNode().dependencies.dependency
+
+                    // Include only configured dependencies
+                    dependencies.each {
+                        if (!DEPENDENCIES.contains(it.artifactId.last().value())) {
+                            it.parent().remove(it)
+                        }
+                    }
                 }
             }
         }

--- a/java/lib/build.gradle
+++ b/java/lib/build.gradle
@@ -18,7 +18,9 @@
 import com.github.spotbugs.snom.SpotBugsTask
 
 import org.apache.tools.ant.filters.ReplaceTokens
+import org.gradle.api.attributes.java.TargetJvmEnvironment
 import org.gradle.internal.os.OperatingSystem
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
 import java.util.regex.Pattern
 
@@ -601,6 +603,41 @@ artifacts {
 project.afterEvaluate {
     tasks.withType(Tar) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
     tasks.withType(Zip) { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
+}
+
+// Include Android variant definition in Gradle Module Metadata
+def androidApiConfig = configurations.create("androidApi").tap {
+    canBeResolved = false
+    canBeConsumed = true
+    attributes {
+        attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objects.named(TargetJvmEnvironment.class, TargetJvmEnvironment.ANDROID))
+        attribute(KotlinPlatformType.attribute, KotlinPlatformType.androidJvm)
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
+    }
+}
+
+dependencies {
+    androidApi("com.couchbase.lite:couchbase-lite-android:$version")
+}
+
+def androidRuntimeConfig = configurations.create("androidRuntime").tap {
+    extendsFrom(androidApiConfig)
+    canBeResolved = false
+    canBeConsumed = true
+    attributes {
+        attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objects.named(TargetJvmEnvironment.class, TargetJvmEnvironment.ANDROID))
+        attribute(KotlinPlatformType.attribute, KotlinPlatformType.androidJvm)
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_RUNTIME))
+    }
+}
+
+(components.java as AdhocComponentWithVariants).with {
+    addVariantsFromConfiguration(androidApiConfig) {
+        mapToMavenScope("compile")
+    }
+    addVariantsFromConfiguration(androidRuntimeConfig) {
+        mapToMavenScope("runtime")
+    }
 }
 
 publishing {

--- a/java/lib/build.gradle
+++ b/java/lib/build.gradle
@@ -610,6 +610,7 @@ def androidApiConfig = configurations.create("androidApi").tap {
     canBeResolved = false
     canBeConsumed = true
     attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.LIBRARY))
         attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objects.named(TargetJvmEnvironment.class, TargetJvmEnvironment.ANDROID))
         attribute(KotlinPlatformType.attribute, KotlinPlatformType.androidJvm)
         attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
@@ -626,6 +627,7 @@ def androidRuntimeConfig = configurations.create("androidRuntime").tap {
     canBeResolved = false
     canBeConsumed = true
     attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.LIBRARY))
         attribute(TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE, objects.named(TargetJvmEnvironment.class, TargetJvmEnvironment.ANDROID))
         attribute(KotlinPlatformType.attribute, KotlinPlatformType.androidJvm)
         attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_RUNTIME))

--- a/java/lib/build.gradle
+++ b/java/lib/build.gradle
@@ -612,7 +612,7 @@ publishing {
             artifactId "${JAR_ARTIFACT}${suffix}"
             version BUILD_VERSION
 
-            artifact jar
+            from components.java
             artifact sourcesJar
             artifact javadocJar
 
@@ -643,20 +643,6 @@ publishing {
                     url = CBL_SITE_URL
                     connection = CBL_PROJECT_URL
                     developerConnection = CBL_PROJECT_URL
-                }
-
-                withXml {
-                    def dependenciesNode = asNode().appendNode('dependencies')
-
-                    // Include only configured dependencies
-                    configurations.implementation.allDependencies.each {
-                        if (DEPENDENCIES.contains(it.name)) {
-                            def dep = dependenciesNode.appendNode('dependency')
-                            dep.appendNode('groupId', it.group)
-                            dep.appendNode('artifactId', it.name)
-                            dep.appendNode('version', it.version)
-                        }
-                    }
                 }
             }
         }

--- a/java/lib/build.gradle
+++ b/java/lib/build.gradle
@@ -616,6 +616,7 @@ def androidApiConfig = configurations.create("androidApi").tap {
     }
 }
 
+// Add variant artifact as a dependencies, since it's in another module
 dependencies {
     androidApi("com.couchbase.lite:couchbase-lite-android:$version")
 }


### PR DESCRIPTION
This allows Gradle to identify the `com.couchbase.lite:couchbase-lite-java` and `com.couchbase.lite:couchbase-lite-android` artifacts as platform-specific variants of the same library. If both dependencies show up in a Gradle configuration, Gradle will choose the one appropriate for the platform being compiled and exclude the other variant.

[These changes](https://github.com/couchbase/couchbase-lite-java-ce/commit/3d5302c6312198fbfaa90a8bac30b8e7f23c408d) allow the publication to include a [Gradle Module Metadata](https://blog.gradle.org/gradle-metadata-1.0) .module file, which contains similar info to the .pom, but has [additional features](https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md), such as being [variant aware](https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md#variants-value).

[These changes](https://github.com/couchbase/couchbase-lite-java-ce/commit/d3b1f4e187b3b4cfe2faf373e6f07164d8e2b758) define the other platform variant in the .module metadata. Since the `java` and `android` variants are each published from their own module, the other platform variant is published as a variant dependency, similar to [this workaround](https://jakewharton.com/multiplatform-compose-and-gradle-module-metadata-abuse/), but utilizing Gradle APIs.

The current versions of the Android Gradle Plugin (7.1-8.2) are using the Kotlin Gradle Plugin to create their publication variant components, which wraps the `AdhocComponentWithVariants` API that is required to [add additional variants](https://docs.gradle.org/current/userguide/publishing_customization.html#ex-adding-a-variant-to-an-existing-software-component) to a component. So reflection is needed to access this API in the Android module, but this can be replaced with a direct cast of the component, the same as the Java module, if [my fix](https://youtrack.jetbrains.com/issue/KT-58830) is accepted in the Kotlin Gradle Plugin.