### PR TITLE
CBL-6167: Expose DatabaseConfig FullSync property in the Kotlin extension package

### DIFF
--- a/common/main/kotlin/com/couchbase/lite/ConfigurationFactories.kt
+++ b/common/main/kotlin/com/couchbase/lite/ConfigurationFactories.kt
@@ -35,10 +35,14 @@ val DatabaseConfigurationFactory: DatabaseConfiguration? = null
  *
  * @see com.couchbase.lite.DatabaseConfiguration
  */
-fun DatabaseConfiguration?.newConfig(databasePath: String? = null): DatabaseConfiguration {
+fun DatabaseConfiguration?.newConfig(
+    databasePath: String? = null,
+    fullSync: Boolean? = null
+): DatabaseConfiguration {
     val config = DatabaseConfiguration()
 
     (databasePath ?: this?.directory)?.let { config.directory = it }
+    (fullSync ?: this?.isFullSync)?.let { config.setFullSync(it) }
 
     return config
 }

--- a/common/test/kotlin/com/couchbase/lite/ConfigFactoryTest.kt
+++ b/common/test/kotlin/com/couchbase/lite/ConfigFactoryTest.kt
@@ -36,20 +36,35 @@ class ConfigFactoryTest : BaseDbTest() {
     ///// Database Configuration
 
     @Test
-    fun testDatabaseConfigurationFactory() {
-        val config = DatabaseConfigurationFactory.newConfig(databasePath = testPath)
-        assertEquals(testPath, config.directory)
+    fun testDatabaseConfigurationFactoryDefaults() {
+        val config = DatabaseConfigurationFactory.newConfig()
+        assertEquals(Defaults.Database.FULL_SYNC, config.isFullSync)
     }
 
     @Test
-    fun testFullTextIndexConfigurationFactoryCopyWithChanges() {
-        val config1 = DatabaseConfigurationFactory.newConfig(databasePath = testPath)
+    fun testDatabaseConfigurationFactory() {
+        val config = DatabaseConfigurationFactory.newConfig(
+            databasePath = testPath,
+            fullSync = true
+        )
+        assertEquals(testPath, config.directory)
+        assertTrue(config.isFullSync)
+    }
+
+    @Test
+    fun testDatabaseConfigurationFactoryCopyWithChanges() {
+        val config1 = DatabaseConfigurationFactory.newConfig(
+            databasePath = testPath,
+            fullSync = true
+        )
 
         val config2 = config1.newConfig()
 
         assertEquals(testPath, config1.directory)
+        assertTrue(config1.isFullSync)
 
         assertEquals(testPath, config2.directory)
+        assertTrue(config2.isFullSync)
     }
 
     ///// ReplicatorConfiguration

--- a/java/etc/ld/jni_gnu.ld
+++ b/java/etc/ld/jni_gnu.ld
@@ -15,8 +15,8 @@ CBL {
         Java_com_couchbase_lite_internal_core_C4TestUtils_free;
         Java_com_couchbase_lite_internal_core_C4TestUtils_freeStore;
         Java_com_couchbase_lite_internal_core_C4TestUtils_getDocID;
-        Java_com_couchbase_lite_internal_core_C4TestUtils_getFlags;
         Java_com_couchbase_lite_internal_core_C4TestUtils_getDocument;
+        Java_com_couchbase_lite_internal_core_C4TestUtils_getFlags;
         Java_com_couchbase_lite_internal_core_C4TestUtils_getLevel;
         Java_com_couchbase_lite_internal_core_C4TestUtils_getPrivateUUID;
         Java_com_couchbase_lite_internal_core_C4TestUtils_next;


### PR DESCRIPTION
This is identical to the Beryllium patch for the same issue