### PR TITLE
CBL-6516: create release validation task

### DIFF
--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -18,7 +18,7 @@
 buildscript {
     ext {
         COMPILE_SDK_VERSION = 32
-        BUILD_TOOLS_VERSION = '33.0.1'
+        BUILD_TOOLS_VERSION = '34.0.0'
         KOTLIN_VERSION = '1.7.20'
 
         ANDROID_MIN_SDK = 22
@@ -35,7 +35,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${KOTLIN_VERSION}"
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.4.0'
     }
 }
 

--- a/android-ktx/gradle.properties
+++ b/android-ktx/gradle.properties
@@ -25,5 +25,4 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Using androidX libraries
 android.useAndroidX=true
 android.enableJetifier=false
-android.disableAutomaticComponentCreation=true
 

--- a/android-ktx/gradle/wrapper/gradle-wrapper.properties
+++ b/android-ktx/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android-ktx/lib/build.gradle
+++ b/android-ktx/lib/build.gradle
@@ -71,11 +71,7 @@ ext {
 def TEST_FILTER = (!project.hasProperty("testFilter")) ? null : testFilter.replaceAll("\\s", "")
 
 // Target repo for maven publish
-def MAVEN_URL = (project.hasProperty("mavenUrl")) ? mavenUrl : "http://nowhere.void/"
-
-// Set true to use mavenLocal instead of Proget
-def USE_LOCAL_MAVEN = project.hasProperty("useLocalMaven")
-
+def MAVEN_URL = (!project.hasProperty("mavenUrl")) ? null : mavenUrl
 
 // ----------------------------------------------------------------
 // Build
@@ -99,6 +95,8 @@ android {
 
     // mumbo-jumbo to prevent "More than one file was found" message
     packagingOptions { exclude 'META-INF/library_release.kotlin_module' }
+
+    buildFeatures { buildConfig true }
 
     defaultConfig {
         minSdkVersion ANDROID_MIN_SDK
@@ -171,18 +169,23 @@ android {
 }
 
 repositories {
-    if (USE_LOCAL_MAVEN) { mavenLocal() }
+    if (BUILD_NUMBER == "SNAPSHOT") {
+        // For dev builds, CBL-Android is in maven local
+        mavenLocal()
+    }
     else {
+        // For official builds CBL-Android is in the internal proget staging feed
         maven {
-            url "http://proget.build.couchbase.com/maven2/cimaven"
-            allowInsecureProtocol = true
+            url "https://proget.sc.couchbase.com/maven2/cimaven"
+            content { includeGroupByRegex "com\\.couchbase\\.lite.*" }
         }
     }
+
     google()
     mavenCentral()
 }
 
-configurations.all { resolutionStrategy.cacheChangingModulesFor 1, 'minutes' }
+configurations.all { resolutionStrategy.cacheChangingModulesFor 1, 'seconds' }
 dependencies {
     // androidx.work:work-runtime-ktx:2.7.1 requires 1.2.0
     compileOnly 'androidx.annotation:annotation:1.2.0'

--- a/android-ktx/test/build.gradle
+++ b/android-ktx/test/build.gradle
@@ -39,7 +39,11 @@ ext {
 
     BUILD_RELEASE = file("${ROOT_DIR}/version.txt").text.trim()
     BUILD_NUMBER = (project.hasProperty("buildNumber") && buildNumber) ? buildNumber : "SNAPSHOT"
-    BUILD_VERSION = "${BUILD_RELEASE}-${BUILD_NUMBER}"
+
+    // if validating a release, we'll use the released bits
+    BUILD_VERSION = "${BUILD_RELEASE}" 
+    // normally, though, we will use a local build
+    if (BUILD_NUMBER != "RELEASE") { BUILD_VERSION = "${BUILD_VERSION}-${BUILD_NUMBER}" }
 
     CBL_COMMON_ROOT_DIR = "${ROOT_DIR}/common"
     CBL_COMMON_DIR = "${CBL_COMMON_ROOT_DIR}/common"
@@ -51,13 +55,15 @@ ext {
 
     CBL_ANDROID_LIB = 'couchbase-lite-android-ktx'
 }
+ 
+// This module is for testing on Jenkins.  Require a build number
+if (BUILD_NUMBER == "SNAPSHOT") { throw new InvalidUserDataException ("!!! A build number is required") }
 
 // comma separated list of annotations for tests that should not be run.
 // e.g., -PtestFilter='com.couchbase.lite.internal.utils.SlowTest,com.couchbase.lite.internal.utils.VerySlowTest'
 def TEST_FILTER = (!project.hasProperty("testFilter")) ? null : testFilter.replaceAll("\\s", "")
 
-// Set true to use mavenLocal instead of Proget
-def USE_LOCAL_MAVEN = project.hasProperty("useLocalMaven")
+print "Testing ${BUILD_VERSION}"
 
 
 // ----------------------------------------------------------------
@@ -143,13 +149,18 @@ android {
 }
 
 repositories {
-    if (USE_LOCAL_MAVEN) { mavenLocal() }
-    else {
-        maven {
-            url "http://proget.build.couchbase.com/maven2/cimaven"
-            allowInsecureProtocol = true
+    maven {
+        if (BUILD_NUMBER == "RELEASE") {
+            // Validate a released build
+            url "https://mobile.maven.couchbase.com/maven2/dev/"
         }
+        else {
+            // Test a cimaven candidate
+            url "https://proget.sc.couchbase.com/maven2/cimaven"
+        }
+        content { includeGroupByRegex "com\\.couchbase\\.lite.*" }
     }
+
     google()
     mavenCentral()
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@
 buildscript {
     ext {
         COMPILE_SDK_VERSION = 32
-        BUILD_TOOLS_VERSION = '33.0.1'
+        BUILD_TOOLS_VERSION = '34.0.0'
         KOTLIN_VERSION = '1.7.20'
 
         ANDROID_MIN_SDK = 22
@@ -35,7 +35,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${KOTLIN_VERSION}"
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.4.0'
         classpath 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.13'
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -25,5 +25,4 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Using androidX libraries
 android.useAndroidX=true
 android.enableJetifier=false
-android.disableAutomaticComponentCreation=true
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/lib/build.gradle
+++ b/android/lib/build.gradle
@@ -77,7 +77,7 @@ ext {
 def TEST_FILTER = (!project.hasProperty("testFilter")) ? null : testFilter.replaceAll("\\s", "")
 
 // Target repo for maven publish
-def MAVEN_URL = (project.hasProperty("mavenUrl")) ? mavenUrl : "http://nowhere.void/"
+def MAVEN_URL = (!project.hasProperty("mavenUrl")) ? null : mavenUrl
 
 
 // ----------------------------------------------------------------
@@ -117,6 +117,8 @@ android {
     }
 
     kotlinOptions { jvmTarget = '1.8' }
+
+    buildFeatures { buildConfig true }
 
     defaultConfig {
         minSdkVersion ANDROID_MIN_SDK
@@ -223,7 +225,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'androidx.annotation:annotation:1.5.0'
+    compileOnly 'androidx.annotation:annotation:1.2.0'
     compileOnly "com.github.spotbugs:spotbugs-annotations:${SPOTBUGS_VERSION}"
 
     //noinspection GradleDependency
@@ -248,19 +250,18 @@ dependencies {
 task javadoc(type: Javadoc) {
     failOnError false
 
-    afterEvaluate { dependsOn generateReleaseBuildConfig, generateReleaseRFile, compileReleaseKotlin }
-
-    source android.sourceSets.main.java.srcDirs
+    source project.android.sourceSets.main.java.srcDirs
     exclude "com/couchbase/lite/internal/**"
 
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    classpath += project.files(android.sourceSets.main.java.srcDirs.join(File.pathSeparator))
-    classpath += project.files("${buildDir}/generated/source/buildConfig/release")
     afterEvaluate {
-        classpath += files(
-            android.libraryVariants.collect { variant ->
-                if (variant.name == "release") { variant.javaCompileProvider.get().classpath.files }
-            })
+        dependsOn generateReleaseBuildConfig, generateReleaseRFile, compileReleaseKotlin
+    
+        classpath += project.files(project.android.getBootClasspath().join(File.pathSeparator))
+        classpath += project.files(project.android.sourceSets.main.java.srcDirs.join(File.pathSeparator))
+        classpath += project.files("${buildDir}/generated/source/buildConfig/release")
+        classpath += files(project.android.libraryVariants.collect { variant ->
+            if (variant.name == "release") { variant.javaCompileProvider.get().classpath.files }
+        })
     }
 
     options {

--- a/java/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java/lib/build.gradle
+++ b/java/lib/build.gradle
@@ -147,12 +147,12 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'androidx.annotation:annotation:1.5.0'
+    compileOnly 'androidx.annotation:annotation:1.2.0'
     compileOnly "com.github.spotbugs:spotbugs-annotations:${SPOTBUGS_VERSION}"
 
     implementation "com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}"
 
-    testCompileOnly 'androidx.annotation:annotation:1.5.0'
+    testCompileOnly 'androidx.annotation:annotation:1.3.0'
 
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${KOTLIN_VERSION}"
     testImplementation 'junit:junit:4.13.2'
@@ -363,11 +363,11 @@ task checkstyle(type: Checkstyle) {
 
     reports {
         xml {
-            enabled = true
+            required = true
             outputLocation = file("${REPORTS_DIR}/checkstyle.xml")
         }
         html {
-            enabled = true
+            required = true
             outputLocation = file("${REPORTS_DIR}/checkstyle.html")
         }
     }
@@ -391,11 +391,11 @@ task pmd(type: Pmd) {
 
     reports {
         xml {
-            enabled = true
+            required = true
             outputLocation = file("${REPORTS_DIR}/pmd.xml")
         }
         html {
-            enabled = true
+            required = true
             outputLocation = file("${REPORTS_DIR}/pmd.html")
         }
     }

--- a/java/test/build.gradle
+++ b/java/test/build.gradle
@@ -39,7 +39,11 @@ ext {
 
     BUILD_RELEASE = file("${ROOT_DIR}/version.txt").text.trim()
     BUILD_NUMBER = (project.hasProperty("buildNumber") && buildNumber) ? buildNumber : "SNAPSHOT"
-    BUILD_VERSION = "${BUILD_RELEASE}-${BUILD_NUMBER}"
+
+    // if validating a release, we'll use the released bits
+    BUILD_VERSION = "${BUILD_RELEASE}"
+    // normally, though, we will use a local build
+    if (BUILD_NUMBER != "RELEASE") { BUILD_VERSION = "${BUILD_VERSION}-${BUILD_NUMBER}" }
 
     CBL_COMMON_ROOT_DIR = "${ROOT_DIR}/common"
     CBL_COMMON_DIR= "${CBL_COMMON_ROOT_DIR}/common"
@@ -49,13 +53,14 @@ ext {
     CBL_CE_JAVA_DIR = "${CBL_CE_ROOT_DIR}/java"
 
     REPORTS_DIR = "${buildDir}/reports"
-    ETC_DIR = "${CBL_COMMON_ROOT_DIR}/etc"
 
     CBL_NATIVE_DIR = "${buildDir}/native"
 
     CBL_JAVA_LIB = 'couchbase-lite-java'
-    if (BUILD_NUMBER == "SNAPSHOT") { CBL_JAVA_LIB = "${CBL_JAVA_LIB}-macos" }
 }
+
+// This module is for testing on Jenkins.  Require a build number
+if (BUILD_NUMBER == "SNAPSHOT") { throw new InvalidUserDataException ("!!! A build number is required") }
 
 // comma separated list of annotations for tests that should not be run.
 // e.g., -PtestFilter='com.couchbase.lite.internal.utils.SlowTest,com.couchbase.lite.internal.utils.VerySlowTest'
@@ -64,6 +69,7 @@ def TEST_FILTER = (!project.hasProperty("testFilter")) ? null : testFilter.repla
 // Set -Pverbose to get full console logs for tests
 def VERBOSE = project.hasProperty("verbose")
 
+print "Testing ${BUILD_VERSION}"
 
 // ----------------------------------------------------------------
 // Build
@@ -99,17 +105,24 @@ java {
 }
 
 repositories {
-    if (BUILD_NUMBER == "SNAPSHOT") { mavenLocal() }
     maven {
-        url "http://proget.build.couchbase.com/maven2/cimaven"
-        allowInsecureProtocol = true
+        if (BUILD_NUMBER == "RELEASE") {
+            // Validate a release
+            url "https://mobile.maven.couchbase.com/maven2/dev/"
+        }
+        else {
+            // Test a release candidate
+            url "https://proget.sc.couchbase.com/maven2/cimaven"
+        }
+        content { includeGroupByRegex "com\\.couchbase\\.lite.*" }
     }
+
     google()
     mavenCentral()
 }
 
 dependencies {
-    testCompileOnly 'androidx.annotation:annotation:1.5.0'
+    testCompileOnly 'androidx.annotation:annotation:1.2.0'
 
     testImplementation "com.couchbase.lite:${CBL_JAVA_LIB}:${BUILD_VERSION}"
 


### PR DESCRIPTION
Also, apparently a recent change in one of the Android Gradle plugin libraries made it impossible to run Android tests.  Toolchain updated to get them running again.