### PR TITLE
CBL-6571: protect static methods of FLResultSet from minification

### DIFF
--- a/android/lib/consumer-rules.pro
+++ b/android/lib/consumer-rules.pro
@@ -19,6 +19,7 @@
     <fields>;
 }
 -keep class com.couchbase.lite.internal.fleece.FLSliceResult {
+    static <methods>;
     <fields>;
     <init>(...);
 }


### PR DESCRIPTION
Fix the consumer proguard rules.