### PR TITLE
Fix AGP 9 Kotlin source set config

### DIFF
--- a/android-ktx/lib/build.gradle.kts
+++ b/android-ktx/lib/build.gradle.kts
@@ -126,7 +126,7 @@ android {
     sourceSets {
         getByName("main") {
             manifest.srcFile("${cblCommonAndroidKtxDir}/main/AndroidManifest.xml")
-            java.directories.addAll(setOf(
+            kotlin.directories.addAll(setOf(
                 "${cblCommonDir}/main/kotlin",
                 "${cblCommonAndroidKtxDir}/main/kotlin",
                 "${cblCECommonDir}/main/kotlin",
@@ -140,11 +140,13 @@ android {
         getByName("androidTest") {
             java.directories.addAll(setOf(
                 "${cblCommonDir}/test/java",
+                "${cblCommonAndroidDir}/androidTest/java"
+            ))
+            kotlin.directories.addAll(setOf(
+                "${cblCommonDir}/test/java",
                 "${cblCommonAndroidDir}/androidTest/java",
                 "${cblCommonDir}/test/kotlin",
-                "${cblCECommonDir}/test/java",
                 "${cblCECommonDir}/test/kotlin",
-                "${cblCEAndroidDir}/lib/src/androidTest/java",
                 "${cblCommonAndroidKtxDir}/androidTest/kotlin",
                 "src/androidTest/kotlin"
             ))

--- a/android/lib/build.gradle.kts
+++ b/android/lib/build.gradle.kts
@@ -163,7 +163,7 @@ android {
                 setOf(
                     "${cblCommonDir}/main/java",                   // Common
                     "${cblCommonAndroidDir}/main/java",           // Common Android
-                    "${cblCECommonDir}/main/java",                // EE Common
+                    "${cblCECommonDir}/main/java",                // CE Common
                     "src/main/java"
                 )
             )
@@ -176,6 +176,14 @@ android {
         }
         getByName("androidTest") {
             java.directories.addAll(
+                setOf(
+                    "${cblCommonDir}/test/java",                   // Common tests
+                    "${cblCommonAndroidDir}/androidTest/java",    // Common Android tests
+                    "${cblCECommonDir}/test/java",                // CE Common tests
+                    "src/androidTest/java"                           // CE Android tests
+                )
+            )
+            kotlin.directories.addAll(
                 setOf(
                     "${cblCommonDir}/test/java",                   // Common tests
                     "${cblCommonAndroidDir}/androidTest/java",    // Common Android tests


### PR DESCRIPTION
* AGP 9 requires Kotlin sources to be registered via kotlin.directories separately from java.directories.

* Add kotlin.directories for androidTest source sets that contain .kt files

* Switch KTX main source sets from java.directories to kotlin.directories since they contain only .kt files.