### PR TITLE
Add includeCBLAndroidSource option to link with android source for android-ktx

### DIFF
--- a/android-ktx/gradle.properties
+++ b/android-ktx/gradle.properties
@@ -26,3 +26,6 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 android.useAndroidX=true
 android.enableJetifier=false
 
+# Dev only: use ../android source instead of Maven for couchbase-lite-android.
+# When enabled, run tasks as :android-ktx instead of :lib.
+#includeCBLAndroidSource=true

--- a/android-ktx/settings.gradle.kts
+++ b/android-ktx/settings.gradle.kts
@@ -26,3 +26,22 @@ if (providers.gradleProperty("automatedTests").map { it.toBoolean() }.getOrElse(
 } else {
     include(":lib")
 }
+
+// Set includeCBLAndroidSource=true in gradle.properties to use ../android source instead of Maven.
+val includeCBLAndroidSource = providers.gradleProperty("includeCBLAndroidSource")
+    .map(String::toBoolean)
+    .getOrElse(false)
+
+if (includeCBLAndroidSource) {
+    // Rename this build's :lib to avoid conflict with project(":lib") in the Android build.
+    project(":lib").name = "android-ktx"
+
+    includeBuild("../android") {
+        name = "couchbase-lite-android-build"
+
+        dependencySubstitution {
+            substitute(module("com.couchbase.lite:couchbase-lite-android"))
+                .using(project(":lib"))
+        }
+    }
+}


### PR DESCRIPTION
* Add includeCBLAndroidSource to include the source directly instead of depending on CBL-Android on maven.

* Related PR : https://github.com/couchbaselabs/couchbase-lite-java-ee-root/pull/416