### PR TITLE
CBL-7230: Clarify default collection use in ReplicatorConfiguration with Database

### DIFF
--- a/common/main/java/com/couchbase/lite/ReplicatorConfiguration.java
+++ b/common/main/java/com/couchbase/lite/ReplicatorConfiguration.java
@@ -33,6 +33,13 @@ public final class ReplicatorConfiguration extends AbstractReplicatorConfigurati
     /**
      * Create a Replicator Configuration
      *
+     * <p>When using this constructor, the default collection of the provided
+     * database will be automatically included in the configuration.</p>
+     *
+     * <p>If you do not intend to replicate the default collection, use
+     * ReplicatorConfiguration(Endpoint) instead, and explicitly add
+     * the intended collections to avoid unintended behavior.</p>
+     *
      * @param database the database to be synchronized
      * @param target   the endpoint with which to synchronize it
      * @deprecated Use ReplicatorConfiguration(Endpoint)


### PR DESCRIPTION
Add Javadoc notes clarifying that ReplicatorConfiguration(Database, Endpoint) uses the default collection. Some users have found this behavior confusing or undocumented.