### PR TITLE
CBL-8389 : Add kotlinx-serialization to android-ktx builds

### DIFF
--- a/android-ktx/lib/build.gradle.kts
+++ b/android-ktx/lib/build.gradle.kts
@@ -182,6 +182,7 @@ dependencies {
     compileOnly(libs.androidx.annotation)
 
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.core)
     implementation(libs.androidx.work.runtime.ktx)
     implementation("com.couchbase.lite:${cblAndroidLib}:${buildVersion}")
 

--- a/android-ktx/test/build.gradle.kts
+++ b/android-ktx/test/build.gradle.kts
@@ -24,6 +24,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 
@@ -160,6 +161,7 @@ dependencies {
     compileOnly(libs.androidx.annotation)
 
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.core)
 
     // Work Manager support
     implementation(libs.androidx.work.runtime.ktx)


### PR DESCRIPTION
* Add kotlinx-serialization-core dependency to android-ktx lib.
* Apply kotlin-serialization plugin and add kotlinx-serialization-core to the android-ktx test app.