### PR TITLE
Fix nullability mismatch in deprecated newConfig extension

### DIFF
--- a/common/main/kotlin/com/couchbase/lite/ConfigurationFactories.kt
+++ b/common/main/kotlin/com/couchbase/lite/ConfigurationFactories.kt
@@ -100,7 +100,7 @@ fun ReplicatorConfiguration?.newConfig(
     val endPt =
         target ?: this?.target ?: throw IllegalArgumentException("A ReplicatorConfiguration must specify an endpoint")
     val config = if (collections == null) {
-        ReplicatorConfiguration(endPt, getCollectionConfigs(this))
+        ReplicatorConfiguration(endPt, this?.let { getCollectionConfigs(it) })
     } else {
         val rc = ReplicatorConfiguration(endPt)
         // Lint will flip out if you try to use `forEach` here.


### PR DESCRIPTION
## Problem

`./gradlew ciBuild` fails to compile with:

```
e: ConfigurationFactories.kt:103:61 Type mismatch: inferred type is ReplicatorConfiguration? but BaseReplicatorConfiguration was expected
```

`getCollectionConfigs()` was tightened to take a non-null `BaseReplicatorConfiguration` (CBL-7303), but the re-added 3.x deprecated `ReplicatorConfiguration?.newConfig` extension still passes its nullable receiver `this`, breaking compilation.

## Fix

Guard the call with `this?.let { getCollectionConfigs(it) }`.

This matches the 3.3 behavior exactly: the `ReplicatorConfiguration(Endpoint, Map?)` constructor treats a null collection map as empty (`new HashMap<>()`), so a null receiver yields an empty configuration just as `getCollectionConfigs(null)` returned null in 3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)